### PR TITLE
Security: Fix xtrace token exposure in CI scripts

### DIFF
--- a/dockerfiles/scripts/create-branch.sh
+++ b/dockerfiles/scripts/create-branch.sh
@@ -4,7 +4,10 @@
 echo "Starting the create-branch.sh script"
 
 # Authenticate with GitHub using GITHUB_TOKEN
+# Temporarily disable xtrace to prevent token from appearing in logs
+set +x
 echo "$GITHUB_TOKEN" | gh auth login --with-token
+set -x
 
 # Get current branch name
 branch_name=$BRANCH_NAME

--- a/dockerfiles/scripts/generate-binaries.sh
+++ b/dockerfiles/scripts/generate-binaries.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
-# NOTE: The -x flag (xtrace) can expose sensitive tokens in logs.
-# TODO: Wrap token-sensitive commands with set +x / set -x guards
-# See issue #50 for comprehensive fix across all scripts.
+# NOTE: Token-sensitive commands in helper scripts are now wrapped
+# with set +x / set -x guards to prevent exposure in logs.
+# See issue #50 for details.
 
 echo "Starting the generate-binaries.sh script"
 


### PR DESCRIPTION
## Summary

Fixes #50 

This PR completes the security audit and fixes xtrace token exposure across all CI scripts.

## Changes

### Fixed
- **create-branch.sh**: Wrapped `gh auth login` command with `set +x` / `set -x` guards to prevent GITHUB_TOKEN from appearing in logs

### Already Fixed  
- **push-to-repo.sh**: Already has proper protection for git push with embedded token (commit a3fa54d)

### No Action Needed
- **keep-only-binaries.sh**: Contains no sensitive operations (only rsync)
- **generate-binaries.sh**: Only calls helper scripts, updated comment to reflect completion

## Security Impact

**Before**: `GITHUB_TOKEN` was exposed in CI logs when running `create-branch.sh` with xtrace enabled (`bash -x`)

**After**: All token-sensitive operations are now wrapped with `set +x` / `set -x` guards, preventing token leakage in logs

## Verification

All token usages are now properly protected:
```bash
# create-branch.sh
set +x
echo "$GITHUB_TOKEN" | gh auth login --with-token
set -x

# push-to-repo.sh  
set +x
git push --set-upstream https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git "${new_branch_name}"
set -x
```

## Testing

- ✅ Verified all scripts for token usage
- ✅ Confirmed set +x guards are in place for all sensitive operations
- ✅ Updated documentation to reflect completion