### PR TITLE
Optimize: Only generate binaries on merge to master + add manual trigger

### DIFF
--- a/.github/workflows/generate-binaries.yml
+++ b/.github/workflows/generate-binaries.yml
@@ -1,15 +1,19 @@
 name: Generate PNG images and STL files from 3D models
 
 on:
-  # Only run on pull_request to avoid duplicate runs
-  # (push to PR branch triggers pull_request event)
-  pull_request:
-    branches: [ '*' ]
-  # Run on push only to main/master branches (no PR)
+  # Run automatically when code is merged to master
   push:
     branches:
       - master
       - main
+  # Allow manual trigger on any branch for testing
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to generate binaries for'
+        required: false
+        default: ''
+  # Run on schedule for regular updates
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Will build everyday at 4:30 and 16:30


### PR DESCRIPTION
## Summary

Optimizes the binary generation workflow to only run when code is finalized, while still allowing manual testing.

## Changes

### Removed
- ❌ **pull_request trigger**: No longer runs on every PR commit (was wasting ~1+ hours per commit)

### Kept  
- ✅ **push to master/main**: Automatically generates binaries when PRs are merged
- ✅ **scheduled runs**: Daily builds at 4:30 and 16:30 UTC

### Added
- ✨ **workflow_dispatch**: Manual trigger available for any branch via GitHub Actions UI

## Benefits

1. **CI Time Savings**: No more 1+ hour workflow runs on every PR commit
2. **Cleaner PR Process**: PRs focus on code review, not binary generation
3. **Binaries When Needed**: Generated automatically when code merges to master
4. **Testing Flexibility**: Manual trigger available for testing specific branches
5. **Always Up-to-Date**: Scheduled runs ensure binaries stay current

## Usage

### Automatic (default)
Binaries are generated when:
- Code is merged to master (push trigger)
- Daily at 4:30 and 16:30 UTC (scheduled)

### Manual Trigger
To generate binaries for a specific branch:
1. Go to Actions → "Generate PNG images and STL files from 3D models"
2. Click "Run workflow"
3. Select the branch
4. Click "Run workflow"

## Related

This optimization complements:
- PR #40 (fosdem-2025): Fixed workflow configuration and duplicate runs
- Issue #50 / PR #51: Security fixes for token exposure