### PR TITLE
feat: Add comprehensive logging to binary generation workflow

### DIFF
--- a/dockerfiles/scripts/generate-binaries.sh
+++ b/dockerfiles/scripts/generate-binaries.sh
@@ -55,7 +55,12 @@ process_files() {
     log "Starting $file_type generation${img_size:+ ($img_size resolution)} with ${timeout_sec}s timeout..."
 
     local current=0
-    find . -type f -name "*scad" -print0 | while IFS= read -r -d '' file; do
+    find . -type f -iname "*.scad" \
+        -not -path "./vendor/*" \
+        -not -path "./node_modules/*" \
+        -not -path "./third_party/*" \
+        -not -path "./.git/*" \
+        -print0 | while IFS= read -r -d '' file; do
         current=$((current + 1))
         START_TIME=$(date +%s)
         FILE_SIZE=$(get_file_size "$file")
@@ -94,9 +99,14 @@ process_files() {
 log "Creating branch..."
 "${SCRIPT_DIR}/create-branch.sh"
 
-# Count total SCAD files
+# Count total SCAD files (excluding vendor directories)
 log "Counting SCAD files..."
-TOTAL_FILES=$(find . -type f -name "*scad" | wc -l)
+TOTAL_FILES=$(find . -type f -iname "*.scad" \
+    -not -path "./vendor/*" \
+    -not -path "./node_modules/*" \
+    -not -path "./third_party/*" \
+    -not -path "./.git/*" \
+    -print0 | tr -cd '\0' | wc -c)
 log "Found $TOTAL_FILES SCAD files to process"
 
 # Process PNG and STL files using consolidated function


### PR DESCRIPTION
## Summary

Adds comprehensive logging to the binary generation workflow to improve debugging and monitoring capabilities.

## Changes

- **Timestamped logging**: All log messages now include timestamps in format `[YYYY-MM-DD HH:MM:SS]`
- **Progress tracking**: Shows `[X/Y]` counter for each file being processed
- **File size reporting**: Displays human-readable input and output file sizes
- **Timing information**: Tracks and reports processing time for each SCAD file
- **Status indicators**: Visual success (✓) and failure (✗) markers
- **Stage logging**: Clear markers for each major workflow stage

## Example Output

```
[2025-10-28 14:50:00] Found 127 SCAD files to process
[2025-10-28 14:50:01] Starting PNG generation (4096x2160 resolution)...
[2025-10-28 14:50:02] [1/127] Processing PNG: assets/Server Rack/1U/modules/module.scad (15KB)
[2025-10-28 14:51:25] [1/127] ✓ PNG completed in 83s (output: 2.4MB)
[2025-10-28 14:51:26] [2/127] Processing PNG: assets/kluster/center-support.scad (8KB)
...
```

## Benefits

- Quickly identify which files take longest to render
- Spot stuck or problematic SCAD files immediately
- Better visibility into workflow progress
- Easier debugging of timeout issues
- Historical performance data for optimization

## Testing

- [x] Script syntax validated
- [ ] Tested in Docker container environment
- [ ] Verified with actual workflow run

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved logging with timestamps and clear start/step/end messages.
  * Added human-readable size reporting and robust file-size detection across platforms.
  * Unified build flow: consolidated per-file processing with timeouts, timing, size reporting, and failure handling.
  * Added pre-branch and completion logs, plus separate binary filtering and repository push steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->