### PR TITLE
fix: handle 'nothing to commit' case in push-to-repo.sh

### DIFF
--- a/dockerfiles/scripts/push-to-repo.sh
+++ b/dockerfiles/scripts/push-to-repo.sh
@@ -8,6 +8,13 @@ git add .
 branch_name=$BRANCH_NAME
 new_branch_name="binaries-for-$branch_name"
 
+# Check if there are changes to commit
+if git diff --quiet && git diff --cached --quiet; then
+    echo "No changes to commit - binaries are up to date"
+    echo "Ending the push-to-repo.sh script"
+    exit 0
+fi
+
 git commit -m "chore(binaries) New binaries for $branch_name"
 
 # Temporarily disable xtrace to prevent GITHUB_TOKEN from appearing in logs


### PR DESCRIPTION
## Summary

Fixes #56 by adding a check before `git commit` to gracefully handle cases where generated binaries are identical to existing files.

## Changes

Modified `dockerfiles/scripts/push-to-repo.sh` to check for changes before attempting to commit:

```bash
# Check if there are changes to commit
if git diff --quiet && git diff --cached --quiet; then
    echo "No changes to commit - binaries are up to date"
    echo "Ending the push-to-repo.sh script"
    exit 0
fi
```

## Problem Solved

Previously, when the workflow generated binaries that were identical to existing files:
- `git commit` would fail with "nothing to commit"
- Because `generate-binaries.sh` has `set -e`, the script would exit immediately
- The `git push` and `gh pr create` commands would never execute
- The workflow would show as "successful" but no PR would be created

## Behavior After Fix

- ✅ **If binaries changed**: Creates PR as normal
- ✅ **If binaries unchanged**: Exits gracefully with informative log message
- ✅ **In both cases**: Workflow completes successfully

## Testing

This fix can be tested by:
1. Manually triggering the workflow on a branch with no SCAD changes
2. Verifying the workflow completes successfully
3. Checking logs show "No changes to commit - binaries are up to date"
4. Confirming no unnecessary PR is created

## Related Work

- Issue #53: Comprehensive logging (helps diagnose these issues)
- PR #54: Implements the logging improvements
- Issue #55: Parallel processing (future performance improvement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment script robustness by adding a pre-check for uncommitted changes, providing clearer user feedback when no changes are detected, and exiting gracefully instead of proceeding with unnecessary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->